### PR TITLE
Fix compilation under NGINX v1.9.11

### DIFF
--- a/config
+++ b/config
@@ -2,7 +2,7 @@ ngx_addon_name=ngx_http_aws_auth
 
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP
-    ngx_module_name=ngx_http_aws_auth
+    ngx_module_name=ngx_http_aws_auth_module
     ngx_module_incs=
     ngx_module_deps=
     ngx_module_srcs="$ngx_addon_dir/ngx_http_aws_auth.c"


### PR DESCRIPTION
After the latest changes on NGINX dynamic modules, the module can't link
properly to the main NGINX codebase, as it reports a missing symbol:
`ngx_http_aws_auth`.  Apparently, we need to specify the module's
symbol in the `ngx_module_name` directive.