### PR TITLE
URI-encoding canonical requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # AWS proxy module
 
+[![Build Status](https://travis-ci.org/anomalizer/ngx_aws_auth.svg?branch=master)](https://travis-ci.org/anomalizer/ngx_aws_auth)
  [![Gitter chat](https://badges.gitter.im/anomalizer/ngx_aws_auth.png)](https://gitter.im/ngx_aws_auth/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
 
 This nginx module can proxy requests to authenticated S3 backends using Amazon's

--- a/aws_functions.h
+++ b/aws_functions.h
@@ -258,7 +258,7 @@ static inline const ngx_str_t* ngx_aws_auth__request_body_hash(ngx_pool_t *pool,
 // modifies the source in place if it needs to be escaped
 // see http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
 static inline void ngx_aws_auth__escape_uri(ngx_pool_t *pool, ngx_str_t* src) {
-  u_char *escaped_data, *escaped_data_with_slashes;
+  u_char *escaped_data;
   u_int escaped_data_len, escaped_data_with_slashes_len, i, j;
   uintptr_t escaped_count, slashes_count = 0;
 
@@ -286,25 +286,23 @@ static inline void ngx_aws_auth__escape_uri(ngx_pool_t *pool, ngx_str_t* src) {
   // now we need to go back and re-replace each occurrence of %2F with a slash
   escaped_data_with_slashes_len = src->len + (escaped_count - slashes_count) * 2;
   if (slashes_count > 0) {
-    escaped_data_with_slashes = ngx_palloc(pool, escaped_data_with_slashes_len);
-
     for (i = 0, j = 0; i < escaped_data_with_slashes_len; i++) {
       if (j < escaped_data_len - 2 && strncmp((char*) (escaped_data + j), "%2F", 3) == 0) {
-        escaped_data_with_slashes[i] = '/';
+        escaped_data[i] = '/';
         j += 3;
       } else {
-        escaped_data_with_slashes[i] = escaped_data[j];
+        escaped_data[i] = escaped_data[j];
         j++;
       }
     }
 
-    src->data = escaped_data_with_slashes;
     src->len = escaped_data_with_slashes_len;
   } else {
     // no slashes
-    src->data = escaped_data;
     src->len = escaped_data_len;
   }
+
+  src->data = escaped_data;
 }
 
 static inline const ngx_str_t* ngx_aws_auth__canon_url(ngx_pool_t *pool, const ngx_http_request_t *req) {

--- a/test_suite.c
+++ b/test_suite.c
@@ -188,8 +188,8 @@ static void canonical_url_with_qs(void **state) {
 	ngx_str_t curl = ngx_string("foo.php");
 
 	ngx_str_t args;
-	args.data = url.data+8;
-	args.len =9;
+	args.data = url.data + 8;
+	args.len = 9;
 
 	request.uri = url;
 	request.uri_start = request.uri.data;
@@ -200,6 +200,24 @@ static void canonical_url_with_qs(void **state) {
 	const ngx_str_t *canon_url = ngx_aws_auth__canon_url(pool, &request);
     assert_int_equal(canon_url->len, curl.len);
     assert_ngx_string_equal(*canon_url, curl);
+}
+
+static void canonical_url_with_special_chars(void **state) {
+  (void) state; /* unused */
+
+  ngx_str_t url = ngx_string("f&o@o/bar.php");
+  ngx_str_t expected_canon_url = ngx_string("f%26o%40o/bar.php");
+
+  ngx_http_request_t request;
+  request.uri = url;
+  request.uri_start = request.uri.data;
+  request.args_start = url.data + url.len;
+  request.args = EMPTY_STRING;
+  request.connection = NULL;
+
+  const ngx_str_t *canon_url = ngx_aws_auth__canon_url(pool, &request);
+    assert_int_equal(canon_url->len, expected_canon_url.len);
+    assert_ngx_string_equal(*canon_url, expected_canon_url);
 }
 
 static void canonical_request_sans_qs(void **state) {
@@ -257,7 +275,6 @@ static void basic_get_signature(void **state) {
 	assert_string_equal(result.signature->data, "4ed4ec875ff02e55c7903339f4f24f8780b986a9cc9eff03f324d31da6a57690");
 }
 
-
 int main() {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(null_test_success),
@@ -272,6 +289,7 @@ int main() {
         cmocka_unit_test(canonical_qs_subrequest),
         cmocka_unit_test(canonical_url_sans_qs),
         cmocka_unit_test(canonical_url_with_qs),
+        cmocka_unit_test(canonical_url_with_special_chars),
         cmocka_unit_test(signed_headers),
         cmocka_unit_test(canonical_request_sans_qs),
         cmocka_unit_test(basic_get_signature),

--- a/test_suite.c
+++ b/test_suite.c
@@ -205,8 +205,8 @@ static void canonical_url_with_qs(void **state) {
 static void canonical_url_with_special_chars(void **state) {
   (void) state; /* unused */
 
-  ngx_str_t url = ngx_string("f&o@o/bar.php");
-  ngx_str_t expected_canon_url = ngx_string("f%26o%40o/bar.php");
+  ngx_str_t url = ngx_string("f&o@o/b ar.php");
+  ngx_str_t expected_canon_url = ngx_string("f%26o%40o/b%20ar.php");
 
   ngx_http_request_t request;
   request.uri = url;


### PR DESCRIPTION
As requested by AWS, see http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
for more details; but all the iffy details come from the fact that
AWS want some URI encoding, but without encoding forward slashes...

Added a unit test.