### PR TITLE
Fix issue #47, credit erankor

### DIFF
--- a/ngx_http_aws_auth.c
+++ b/ngx_http_aws_auth.c
@@ -65,7 +65,7 @@ static ngx_command_t  ngx_http_aws_auth_commands[] = {
       0,
       0,
       NULL },
-  
+
       ngx_null_command
 };
 
@@ -111,7 +111,7 @@ ngx_http_aws_auth_create_loc_conf(ngx_conf_t *cf)
         return NGX_CONF_ERROR;
     }
 
-    return conf;    
+    return conf;
 }
 
 static char *
@@ -228,7 +228,7 @@ ngx_aws_auth_req_init(ngx_conf_t *cf)
 
     cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
 
-    h = ngx_array_push(&cmcf->phases[NGX_HTTP_ACCESS_PHASE].handlers);
+    h = ngx_array_push(&cmcf->phases[NGX_HTTP_PREACCESS_PHASE].handlers);
     if (h == NULL) {
         return NGX_ERROR;
     }
@@ -237,7 +237,7 @@ ngx_aws_auth_req_init(ngx_conf_t *cf)
 
     return NGX_OK;
 }
-/* 
+/*
  * vim: ts=4 sw=4 et
  */
 


### PR DESCRIPTION
This fixes the issue discussed in https://github.com/anomalizer/ngx_aws_auth/issues/47 . From a comment (https://github.com/kaltura/nginx-vod-module/issues/717#issuecomment-339252129) by @erankor :

> 
> I checked why the aws_auth handler doesn't run for subrequests, and saw that nginx doesn't call access phase handlers for subrequests, but other phase handlers are executed for subrequests.
> So, a quick workaround for this issue is to move ngx_aws_auth from the access phase to the pre-access phase. New nginx versions have a pre-content phase, which is probably the most suitable here, but these versions currently don't work with nginx-vod-module.
> Anyway, just change NGX_HTTP_ACCESS_PHASE to NGX_HTTP_PREACCESS_PHASE in ngx_aws_auth and you should be set.

