### PR TITLE
Fix up some whitespace

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,13 +2,13 @@ Copyright (c) 2010, Arvind Jayaprakash
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ test: .cmocka_build | nginx
 clean:
 	rm -f *.o test_suite
 
-# vim: ft=make ts=8 sw=8 noet	
+# vim: ft=make ts=8 sw=8 noet

--- a/README.md
+++ b/README.md
@@ -21,19 +21,18 @@ Implements proxying of authenticated requests to S3.
     aws_access_key your_aws_access_key; # Example AKIDEXAMPLE
     aws_key_scope scope_of_generated_signing_key; #Example 20150830/us-east-1/service/aws4_request
     aws_signing_key signing_key_generated_using_script; #Example L4vRLWAO92X5L3Sqk5QydUSdB0nC9+1wfqLMOKLbRp4=
-	aws_s3_bucket your_s3_bucket;
+    aws_s3_bucket your_s3_bucket;
 
     location / {
-	  aws_sign;
+      aws_sign;
       proxy_pass http://your_s3_bucket.s3.amazonaws.com;
     }
 
     # This is an example that does not use the server root for the proxy root
-	location /myfiles {
-	
+    location /myfiles {
+
       rewrite /myfiles/(.*) /$1 break;
       proxy_pass http://your_s3_bucket.s3.amazonaws.com/$1;
-
 
       aws_access_key your_aws_access_key;
       aws_key_scope scope_of_generated_signing_key;
@@ -41,8 +40,8 @@ Implements proxying of authenticated requests to S3.
     }
 
     # This is an example that use specific s3 endpoint, default endpoint is s3.amazonaws.com
-	location /s3_beijing {
-	
+    location /s3_beijing {
+
       rewrite /s3_beijing/(.*) /$1 break;
       proxy_pass http://your_s3_bucket.s3.cn-north-1.amazonaws.com.cn/$1;
 
@@ -56,7 +55,7 @@ Implements proxying of authenticated requests to S3.
 ```
 
 ## Security considerations
-The V4 protocol does not need access to the actual secret keys that one obtains 
+The V4 protocol does not need access to the actual secret keys that one obtains
 from the IAM service. The correct way to use the IAM key is to actually generate
 a scoped signing key and use this signing key to access S3. This nginx module
 requires the signing key and not the actual secret key. It is an insecure practise

--- a/aws_functions.h
+++ b/aws_functions.h
@@ -199,7 +199,7 @@ static inline struct AwsCanonicalHeaderDetails ngx_aws_auth__canonize_headers(ng
 	header_ptr = ngx_array_push(settable_header_array);
 	header_ptr->key = AMZ_DATE_HEADER;
 	header_ptr->value = *amz_date;
-	
+
 	header_ptr = ngx_array_push(settable_header_array);
 	header_ptr->key = HOST_HEADER;
 	header_ptr->value.len = s3_bucket->len + 60;
@@ -219,8 +219,8 @@ static inline struct AwsCanonicalHeaderDetails ngx_aws_auth__canonize_headers(ng
 	/* make canonical headers string */
 	retval.canon_header_str = ngx_palloc(pool, sizeof(ngx_str_t));
 	retval.canon_header_str->data = ngx_palloc(pool, header_nameval_size);
-	
-	for(i = 0, used = 0, buf_progress = retval.canon_header_str->data; 
+
+	for(i = 0, used = 0, buf_progress = retval.canon_header_str->data;
 		i < settable_header_array->nelts;
 		i++, used = buf_progress - retval.canon_header_str->data) {
 		buf_progress = ngx_snprintf(buf_progress, header_nameval_size - used, "%V:%V\n",
@@ -228,12 +228,12 @@ static inline struct AwsCanonicalHeaderDetails ngx_aws_auth__canonize_headers(ng
 			& ((header_pair_t*)settable_header_array->elts)[i].value);
 	}
 	retval.canon_header_str->len = used;
-	
+
 	/* make signed headers */
 	retval.signed_header_names = ngx_palloc(pool, sizeof(ngx_str_t));
 	retval.signed_header_names->data = ngx_palloc(pool, header_names_size);
-	
-	for(i = 0, used = 0, buf_progress = retval.signed_header_names->data; 
+
+	for(i = 0, used = 0, buf_progress = retval.signed_header_names->data;
 		i < settable_header_array->nelts;
 		i++, used = buf_progress - retval.signed_header_names->data) {
 		buf_progress = ngx_snprintf(buf_progress, header_names_size - used, "%V;",
@@ -337,17 +337,17 @@ static inline struct AwsCanonicalRequestDetails ngx_aws_auth__make_canonical_req
 		const ngx_http_request_t *req,
 		const ngx_str_t *s3_bucket_name, const ngx_str_t *amz_date, const ngx_str_t *s3_endpoint) {
 	struct AwsCanonicalRequestDetails retval;
-	
+
 	// canonize query string
 	const ngx_str_t *canon_qs = ngx_aws_auth__canonize_query_string(pool, req);
 
 	// compute request body hash
 	const ngx_str_t *request_body_hash = ngx_aws_auth__request_body_hash(pool, req);
 
-	const struct AwsCanonicalHeaderDetails canon_headers = 
+	const struct AwsCanonicalHeaderDetails canon_headers =
 		ngx_aws_auth__canonize_headers(pool, req, s3_bucket_name, amz_date, request_body_hash, s3_endpoint);
 	retval.signed_header_names = canon_headers.signed_header_names;
-	
+
 	const ngx_str_t *http_method = &(req->method_name);
 	const ngx_str_t *url = ngx_aws_auth__canon_url(pool, req);
 
@@ -401,7 +401,7 @@ static inline struct AwsSignedRequestDetails ngx_aws_auth__compute_signature(ngx
 	struct AwsSignedRequestDetails retval;
 
 	const ngx_str_t *date = ngx_aws_auth__compute_request_time(pool, &req->start_sec);
-	const struct AwsCanonicalRequestDetails canon_request = 
+	const struct AwsCanonicalRequestDetails canon_request =
 		ngx_aws_auth__make_canonical_request(pool, req, s3_bucket_name, date, s3_endpoint);
 	const ngx_str_t *canon_request_hash = ngx_aws_auth__hash_sha256(pool, canon_request.canon_request);
 

--- a/ngx_http_aws_auth.c
+++ b/ngx_http_aws_auth.c
@@ -65,7 +65,7 @@ static ngx_command_t  ngx_http_aws_auth_commands[] = {
       0,
       0,
       NULL },
-  
+
       ngx_null_command
 };
 
@@ -111,7 +111,7 @@ ngx_http_aws_auth_create_loc_conf(ngx_conf_t *cf)
         return NGX_CONF_ERROR;
     }
 
-    return conf;    
+    return conf;
 }
 
 static char *
@@ -237,7 +237,7 @@ ngx_aws_auth_req_init(ngx_conf_t *cf)
 
     return NGX_OK;
 }
-/* 
+/*
  * vim: ts=4 sw=4 et
  */
 

--- a/reference-impl-py/reference_v2.py
+++ b/reference-impl-py/reference_v2.py
@@ -54,7 +54,7 @@ def str_to_sign_v2(method, vhost_mode, bucket, url):
 def v2sign(key, method, vhost_mode, bucket, url):
     raw = str_to_sign_v2(method, vhost_mode, bucket, url)
     print "String to sign is\n----------------------\n%s\n---------------------\n" % raw['s2s']
-    retval = hmac.new(key, raw['s2s'], sha1)   
+    retval = hmac.new(key, raw['s2s'], sha1)
     return {'sign': retval.digest().encode("base64").rstrip("\n"),
         'headers': raw['headers']}
 

--- a/test_suite.c
+++ b/test_suite.c
@@ -39,7 +39,7 @@ static void x_amz_date(void **state) {
 	const ngx_str_t* date;
 
     (void) state; /* unused */
-	
+
 	t = 1;
 	date = ngx_aws_auth__compute_request_time(pool, &t);
 	assert_int_equal(date->len, 16);
@@ -100,7 +100,7 @@ static void canon_header_string(void **state) {
     endpoint.data = "s3.amazonaws.com"; endpoint.len = 16;
 
     retval = ngx_aws_auth__canonize_headers(pool, NULL, &bucket, &date, &hash, &endpoint);
-    assert_string_equal(retval.canon_header_str->data, 
+    assert_string_equal(retval.canon_header_str->data,
         "host:bugait.s3.amazonaws.com\nx-amz-content-sha256:f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b\nx-amz-date:20160221T063112Z\n");
 }
 
@@ -227,7 +227,7 @@ static void canonical_request_sans_qs(void **state) {
 	const ngx_str_t url = ngx_string("/");
 	const ngx_str_t method = ngx_string("GET");
   const ngx_str_t endpoint = ngx_string("s3.amazonaws.com");
-	
+
 	struct AwsCanonicalRequestDetails result;
 	ngx_http_request_t request;
 


### PR DESCRIPTION
- tabs to spaces so indentation renders correctly on github
    - automated via: `sed -i 's/\t/    /g' README.md`
- remove trailing whitespace
    - automated via:

      ```bash
      pre-commit try-repo \
          https://github.com/pre-commit/pre-commit-hooks \
          trailing-whitespace --all-files
      ```