### PR TITLE
Remove use of bucket and promote use of endpoint instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Implements proxying of authenticated requests to S3.
     # This is an example that use compatible s3 endpoint (such as minio)
     location /films {
 
-      proxy_pass http://10.1.3.9:9000:9000/films/;
+      proxy_pass http://10.1.3.9:9000/films/;
 
       aws_sign;
       aws_endpoint "10.1.3.9:9000";

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Implements proxying of authenticated requests to S3.
     aws_access_key your_aws_access_key; # Example AKIDEXAMPLE
     aws_key_scope scope_of_generated_signing_key; #Example 20150830/us-east-1/service/aws4_request
     aws_signing_key signing_key_generated_using_script; #Example L4vRLWAO92X5L3Sqk5QydUSdB0nC9+1wfqLMOKLbRp4=
-    aws_s3_bucket your_s3_bucket;
 
     location / {
       aws_sign;
+      aws_endpoint your_s3_bucket.s3.amazonaws.com;
       proxy_pass http://your_s3_bucket.s3.amazonaws.com;
     }
 
@@ -33,10 +33,12 @@ Implements proxying of authenticated requests to S3.
 
       rewrite /myfiles/(.*) /$1 break;
       proxy_pass http://your_s3_bucket.s3.amazonaws.com/$1;
+      
 
       aws_access_key your_aws_access_key;
       aws_key_scope scope_of_generated_signing_key;
       aws_signing_key signing_key_generated_using_script;
+      aws_endpoint your_s3_bucket.s3.amazonaws.com;
     }
 
     # This is an example that use specific s3 endpoint, default endpoint is s3.amazonaws.com
@@ -46,11 +48,24 @@ Implements proxying of authenticated requests to S3.
       proxy_pass http://your_s3_bucket.s3.cn-north-1.amazonaws.com.cn/$1;
 
       aws_sign;
-      aws_endpoint "s3.cn-north-1.amazonaws.com.cn";
+      aws_endpoint "your_s3_bucket.s3.cn-north-1.amazonaws.com.cn";
       aws_access_key your_aws_access_key;
       aws_key_scope scope_of_generated_signing_key;
       aws_signing_key signing_key_generated_using_script;
     }
+
+    # This is an example that use compatible s3 endpoint (such as minio)
+    location /films {
+
+      proxy_pass http://10.1.3.9:9000:9000/films/;
+
+      aws_sign;
+      aws_endpoint "10.1.3.9:9000";
+      aws_access_key your_aws_access_key;
+      aws_key_scope scope_of_generated_signing_key;
+      aws_signing_key signing_key_generated_using_script;
+    }
+
   }
 ```
 

--- a/aws_functions.h
+++ b/aws_functions.h
@@ -204,7 +204,7 @@ static inline struct AwsCanonicalHeaderDetails ngx_aws_auth__canonize_headers(ng
 	header_ptr->key = HOST_HEADER;
 	header_ptr->value.len = s3_bucket->len + 60;
 	header_ptr->value.data = ngx_palloc(pool, header_ptr->value.len);
-	header_ptr->value.len = ngx_snprintf(header_ptr->value.data, header_ptr->value.len, "%V.%V", s3_bucket, s3_endpoint) - header_ptr->value.data;
+	header_ptr->value.len = ngx_snprintf(header_ptr->value.data, header_ptr->value.len, "%V", s3_endpoint) - header_ptr->value.data;
 
 	ngx_qsort(settable_header_array->elts, (size_t) settable_header_array->nelts,
 		sizeof(header_pair_t), ngx_aws_auth__cmp_hnames);

--- a/aws_functions.h
+++ b/aws_functions.h
@@ -165,23 +165,9 @@ static inline const ngx_str_t* ngx_aws_auth__canonize_query_string(ngx_pool_t *p
 	return retval;
 }
 
-
-static inline const ngx_str_t* ngx_aws_auth__host_from_bucket(ngx_pool_t *pool,
-		const ngx_str_t *s3_bucket) {
-	static const char HOST_PATTERN[] = ".s3.amazonaws.com";
-	ngx_str_t *host;
-
-	host = ngx_palloc(pool, sizeof(ngx_str_t));
-	host->len = s3_bucket->len + sizeof(HOST_PATTERN) + 1;
-	host->data = ngx_palloc(pool, host->len);
-	host->len = ngx_snprintf(host->data, host->len, "%V%s", s3_bucket, HOST_PATTERN) - host->data;
-
-	return host;
-}
-
 static inline struct AwsCanonicalHeaderDetails ngx_aws_auth__canonize_headers(ngx_pool_t *pool,
 		const ngx_http_request_t *req,
-		const ngx_str_t *s3_bucket, const ngx_str_t *amz_date,
+		const ngx_str_t *amz_date,
 		const ngx_str_t *content_hash,
     const ngx_str_t *s3_endpoint) {
 	size_t header_names_size = 1, header_nameval_size = 1;
@@ -202,7 +188,7 @@ static inline struct AwsCanonicalHeaderDetails ngx_aws_auth__canonize_headers(ng
 
 	header_ptr = ngx_array_push(settable_header_array);
 	header_ptr->key = HOST_HEADER;
-	header_ptr->value.len = s3_bucket->len + 60;
+	header_ptr->value.len = s3_endpoint->len + 60;
 	header_ptr->value.data = ngx_palloc(pool, header_ptr->value.len);
 	header_ptr->value.len = ngx_snprintf(header_ptr->value.data, header_ptr->value.len, "%V", s3_endpoint) - header_ptr->value.data;
 
@@ -335,7 +321,7 @@ static inline const ngx_str_t* ngx_aws_auth__canon_url(ngx_pool_t *pool, const n
 
 static inline struct AwsCanonicalRequestDetails ngx_aws_auth__make_canonical_request(ngx_pool_t *pool,
 		const ngx_http_request_t *req,
-		const ngx_str_t *s3_bucket_name, const ngx_str_t *amz_date, const ngx_str_t *s3_endpoint) {
+		const ngx_str_t *amz_date, const ngx_str_t *s3_endpoint) {
 	struct AwsCanonicalRequestDetails retval;
 
 	// canonize query string
@@ -345,7 +331,7 @@ static inline struct AwsCanonicalRequestDetails ngx_aws_auth__make_canonical_req
 	const ngx_str_t *request_body_hash = ngx_aws_auth__request_body_hash(pool, req);
 
 	const struct AwsCanonicalHeaderDetails canon_headers =
-		ngx_aws_auth__canonize_headers(pool, req, s3_bucket_name, amz_date, request_body_hash, s3_endpoint);
+		ngx_aws_auth__canonize_headers(pool, req, amz_date, request_body_hash, s3_endpoint);
 	retval.signed_header_names = canon_headers.signed_header_names;
 
 	const ngx_str_t *http_method = &(req->method_name);
@@ -396,13 +382,12 @@ static inline const ngx_str_t* ngx_aws_auth__make_auth_token(ngx_pool_t *pool,
 static inline struct AwsSignedRequestDetails ngx_aws_auth__compute_signature(ngx_pool_t *pool, ngx_http_request_t *req,
 		const ngx_str_t *signing_key,
 		const ngx_str_t *key_scope,
-		const ngx_str_t *s3_bucket_name,
     const ngx_str_t *s3_endpoint) {
 	struct AwsSignedRequestDetails retval;
 
 	const ngx_str_t *date = ngx_aws_auth__compute_request_time(pool, &req->start_sec);
 	const struct AwsCanonicalRequestDetails canon_request =
-		ngx_aws_auth__make_canonical_request(pool, req, s3_bucket_name, date, s3_endpoint);
+		ngx_aws_auth__make_canonical_request(pool, req, date, s3_endpoint);
 	const ngx_str_t *canon_request_hash = ngx_aws_auth__hash_sha256(pool, canon_request.canon_request);
 
 	// get string to sign
@@ -423,9 +408,8 @@ static inline const ngx_array_t* ngx_aws_auth__sign(ngx_pool_t *pool, ngx_http_r
 		const ngx_str_t *access_key_id,
 		const ngx_str_t *signing_key,
 		const ngx_str_t *key_scope,
-		const ngx_str_t *s3_bucket_name,
     const ngx_str_t *s3_endpoint) {
-	const struct AwsSignedRequestDetails signature_details = ngx_aws_auth__compute_signature(pool, req, signing_key, key_scope, s3_bucket_name, s3_endpoint);
+	const struct AwsSignedRequestDetails signature_details = ngx_aws_auth__compute_signature(pool, req, signing_key, key_scope, s3_endpoint);
 
 
 	const ngx_str_t *auth_header_value = ngx_aws_auth__make_auth_token(pool, signature_details.signature,

--- a/ngx_http_aws_auth.c
+++ b/ngx_http_aws_auth.c
@@ -161,7 +161,7 @@ ngx_http_aws_proxy_sign(ngx_http_request_t *r)
     }
 
     const ngx_array_t* headers_out = ngx_aws_auth__sign(r->pool, r,
-        &conf->access_key, &conf->signing_key_decoded, &conf->key_scope, &conf->bucket_name, &conf->endpoint);
+        &conf->access_key, &conf->signing_key_decoded, &conf->key_scope, &conf->endpoint);
 
     ngx_uint_t i;
     for(i = 0; i < headers_out->nelts; i++)


### PR DESCRIPTION
This change remove the use of aws_bucket. Instead it uses the aws_endpoint to include the bucket_name if needed.
This change allows the use of non-amazon s3 bucket such as minio and can sustain some use cases where the bucket is not in the endpoint.