### PR TITLE
Compile with OpenSSL 1.1.1a

### DIFF
--- a/crypto_helper_openssl.c
+++ b/crypto_helper_openssl.c
@@ -7,13 +7,13 @@
  * releases.
  */
 
+#include "crypto_helper.h"
+
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
-
-#include "crypto_helper.h"
 
 static const EVP_MD* evp_md = NULL;
 


### PR DESCRIPTION
A compile error occurred in combination with OpenSSL 1.1.1a.
The error message is below.

I changed the order of include so that it can be compiled with OpenSSL 1.1.1a.

```
In file included from src/os/unix/ngx_process.h:12,
                 from src/core/ngx_core.h:54,
                 from /tmp/ngx_aws_auth/crypto_helper.h:5,
                 from /tmp/ngx_aws_auth/crypto_helper_openssl.c:16:
src/os/unix/ngx_setaffinity.h:16:9: error: unknown type name 'cpu_set_t'
 typedef cpu_set_t  ngx_cpuset_t;
         ^~~~~~~~~
make[1]: *** [objs/Makefile:1699: objs/addon/ngx_aws_auth/crypto_helper_openssl.o] Error 1
make: *** [Makefile:8: build] Error 2
```