### PR TITLE
Handling PUT requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,8 @@ L4vRLWAO92X5L3Sqk5QydUSdB0nC9+1wfqLMOKLbRp4=
 ```
 
 ## Known limitations
-The 2.x version of the module currently only has support for GET and HEAD calls. This is because
-signing request body is complex and has not yet been implemented.
-
+This version adds support for PUT calls as well. The earlier version of the module only had support
+for GET and HEAD calls.
 
 
 ## Credits

--- a/aws_functions.h
+++ b/aws_functions.h
@@ -60,8 +60,8 @@ struct AwsSignedRequestDetails {
     ngx_log_error(NGX_LOG_ERR, req->connection->log, 0, __VA_ARGS__); \
   }
 
-static const ngx_str_t EMPTY_STRING_SHA256 = ngx_string("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 static const ngx_str_t EMPTY_STRING = ngx_null_string;
+static const ngx_str_t UNSIGNED_PAYLOAD = ngx_string("UNSIGNED-PAYLOAD");
 static const ngx_str_t AMZ_HASH_HEADER = ngx_string("x-amz-content-sha256");
 static const ngx_str_t AMZ_DATE_HEADER = ngx_string("x-amz-date");
 static const ngx_str_t HOST_HEADER = ngx_string("host");
@@ -248,8 +248,7 @@ static inline struct AwsCanonicalHeaderDetails ngx_aws_auth__canonize_headers(ng
 
 static inline const ngx_str_t* ngx_aws_auth__request_body_hash(ngx_pool_t *pool,
 	const ngx_http_request_t *req) {
-	/* TODO: support cases involving non-empty body */
-	return &EMPTY_STRING_SHA256;
+	return &UNSIGNED_PAYLOAD;
 }
 
 // AWS wants a peculiar kind of URI-encoding: they want RFC 3986, except that

--- a/ngx_conf/attempts/nginx.conf.aws_sign2_attempt
+++ b/ngx_conf/attempts/nginx.conf.aws_sign2_attempt
@@ -1,0 +1,47 @@
+# Attempt to sign AWS GET requests correctly
+# This uses AWS signature version 2, which no longer works for S3
+
+events { }
+
+http {
+  upstream myproject {
+    server 10.10.1.1:8080;
+    server 10.10.1.3:8080;
+    server 10.10.1.4:8080;
+  }
+  upstream aws {
+    server small-values.s3.amazonaws.com;
+  }
+
+  server {
+    listen 80;
+    server_name www.domain.com;
+    #location / {
+    #  proxy_pass http://myproject;
+    #}
+    location ~* ^/s3/(.*) {
+      set $bucket           'small-values';
+      set $aws_access       'AKIAJXI6TBS3WIVC2TRA';
+      set $aws_secret       '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';
+      set $url_full         "$1";
+      set_formatted_gmt_time $now "%a, %e %b %Y %H:%M:%S +0000";
+      set $string_to_sign   "$request_method\n\n\nx-amz-date:$now\n/$bucket/$url_full";
+      set_hmac_sha1          $aws_signature $aws_secret $string_to_sign;
+      set_encode_base64      $aws_signature $aws_signature;
+
+      resolver               172.31.0.2 valid=300s;
+      resolver_timeout       10s;
+
+      proxy_http_version     1.1;
+      proxy_set_header       Host $bucket.s3.amazonaws.com;
+      proxy_set_header       x-amz-date $now;
+      proxy_set_header       Authorization "AWS $aws_access:$aws_signature";
+      proxy_buffering        off;
+      proxy_intercept_errors on;
+
+      rewrite .* /$url_full break;
+
+      proxy_pass             http://s3.amazonaws.com;
+    }
+  }
+}

--- a/ngx_conf/attempts/nginx.conf.boto3_attempt
+++ b/ngx_conf/attempts/nginx.conf.boto3_attempt
@@ -1,0 +1,33 @@
+# Attempt to make nginx work with boto3
+# Does not work (yet) - maybe supress all the headers?
+
+events { }
+
+http {
+  proxy_cache_path /usr/local/nginx/cache keys_zone=mycache:10m max_size=50m;
+  server {
+    listen 80;
+    server_name www.domain.com;
+
+    aws_access_key "AKIAJXI6TBS3WIVC2TRA";
+    aws_signing_key "b7nlZ5r3mN7M1h42Bu2N2G0buLAqT0qNydFl1vXJNIc=";
+    aws_key_scope "20190506/ap-southeast-2/s3/aws4_request";
+    aws_s3_bucket "small-values";
+
+    location / {
+      proxy_cache mycache;
+      proxy_buffering on;
+      proxy_ignore_headers Expires;
+      proxy_ignore_headers X-Accel-Expires;
+      proxy_ignore_headers Cache-Control;
+      proxy_ignore_headers Set-Cookie;
+
+      proxy_hide_header X-Accel-Expires;
+      proxy_hide_header Expires;
+      proxy_hide_header Cache-Control;
+      proxy_hide_header Pragma;
+      aws_sign;
+      proxy_pass https://small-values.s3.amazonaws.com;
+    }
+  }
+}

--- a/ngx_conf/attempts/nginx.conf.memcached_attempt
+++ b/ngx_conf/attempts/nginx.conf.memcached_attempt
@@ -1,0 +1,35 @@
+# Attempt for getting memcached to work with nginx - Did not work
+
+events { }
+
+http {
+  server {
+    listen 80;
+    server_name www.domain.com;
+
+    aws_access_key "AKIAJXI6TBS3WIVC2TRA";
+    aws_signing_key "b7nlZ5r3mN7M1h42Bu2N2G0buLAqT0qNydFl1vXJNIc=";
+    aws_key_scope "20190506/ap-southeast-2/s3/aws4_request";
+    aws_s3_bucket "small-values";
+
+    location / {
+      set $memcached_key $uri;
+      memcached_pass 127.0.0.1:11211;
+      error_page 404 = @fallback;
+    }
+
+    location @fallback {
+      aws_sign;
+      proxy_pass https://small-values.s3.amazonaws.com;
+      proxy_ignore_headers Expires;
+      proxy_ignore_headers X-Accel-Expires;
+      proxy_ignore_headers Cache-Control;
+      proxy_ignore_headers Set-Cookie;
+      proxy_hide_header Set-Cookie;
+      proxy_hide_header X-Accel-Expires;
+      proxy_hide_header Expires;
+      proxy_hide_header Cache-Control;
+      proxy_hide_header Pragma;
+    }
+  }
+}

--- a/ngx_conf/working/nginx.conf.put
+++ b/ngx_conf/working/nginx.conf.put
@@ -1,0 +1,21 @@
+# Forwarding PUT requests to S3 proxy
+
+events { }
+
+http {
+  server {
+    listen 80;
+    server_name www.domain.com;
+
+    aws_access_key "AKIAJXI6TBS3WIVC2TRA";
+    aws_signing_key "IugeDgQFXVemJswEm4kRwQpcRn7/ddx6ZNn2uKieIyI=";
+    aws_key_scope "20190508/ap-southeast-2/s3/aws4_request";
+    aws_s3_bucket "small-values";
+
+    location / {
+      proxy_pass_request_body on;
+      aws_sign;
+      proxy_pass https://small-values.s3.amazonaws.com;
+    }
+  }
+}

--- a/ngx_conf/working/nginx.conf.working_get_with_memcached
+++ b/ngx_conf/working/nginx.conf.working_get_with_memcached
@@ -1,0 +1,48 @@
+# Querying memcached before forwarding to S3
+
+events { }
+
+http {
+  upstream memcached {
+    server 127.0.0.1:11211;
+    keepalive 32;
+  }
+
+  server {
+    listen 80;
+    server_name localhost;
+
+    aws_access_key "AKIAJXI6TBS3WIVC2TRA";
+    aws_signing_key "b7nlZ5r3mN7M1h42Bu2N2G0buLAqT0qNydFl1vXJNIc=";
+    aws_key_scope "20190506/ap-southeast-2/s3/aws4_request";
+    aws_s3_bucket "small-values";
+
+    location = /memc {
+        internal;
+
+        memc_connect_timeout 100ms;
+        memc_send_timeout 100ms;
+        memc_read_timeout 100ms;
+        memc_ignore_client_abort on;
+
+        set $memc_key $arg_key;
+        set $memc_exptime 300;
+
+        memc_pass memcached;
+    }
+
+    location / {
+      set $key $uri;
+      srcache_fetch GET /memc key=$key;
+      srcache_methods GET;
+      srcache_store_statuses 200 301 302;
+
+      aws_sign;
+      proxy_pass https://small-values.s3.amazonaws.com;
+      set $key $uri;
+      srcache_request_cache_control off;
+      srcache_store PUT /memc key=$key;
+    }
+
+  }
+}

--- a/ngx_http_aws_auth.c
+++ b/ngx_http_aws_auth.c
@@ -155,7 +155,7 @@ ngx_http_aws_proxy_sign(ngx_http_request_t *r)
     ngx_table_elt_t  *h;
     header_pair_t *hv;
 
-    if (!(r->method & (NGX_HTTP_GET|NGX_HTTP_HEAD))) {
+    if (!(r->method & (NGX_HTTP_GET|NGX_HTTP_PUT|NGX_HTTP_HEAD))) {
         /* We do not wish to support anything with a body as signing for a body is unimplemented */
         return NGX_HTTP_NOT_ALLOWED;
     }


### PR DESCRIPTION
@anomalizer 

Referred to [this](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html) page. Signing the payload is not mandatory, the string `UNSIGNED-PAYLOAD` can be used instead.

Verified that this works for both GET and PUT requests.